### PR TITLE
Fix writing 3D arrays with single channel dimension as monochrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-12-29
+
+- Fix writing 3D arrays with a single channel dimension (shape `(H, W, 1)`) as monochrome
+  images. The last dimension is now automatically collapsed when `num_components == 1`,
+  restoring compatibility with version 0.4.6 behavior.
+
 ## [0.5.0] - 2025-12-29
 
 - Optimize image reading and writing for multi-threaded workloads by releasing the

--- a/tests/test_memory_compression.py
+++ b/tests/test_memory_compression.py
@@ -115,6 +115,20 @@ def test_imwrite_to_memory_consistency():
     )
 
 
+def test_imwrite_3d_single_channel_as_monochrome(tmp_path):
+    test_image = np.random.randint(0, 256, (100, 150, 1), dtype=np.uint8)
+
+    compressed_data = imwrite_to_memory(test_image)
+
+    filename = tmp_path / 'test.j2c'
+    with open(filename, 'wb') as f:
+        f.write(compressed_data.tobytes())
+
+    loaded_image = imread(filename)
+    expected_image = test_image.squeeze()
+    np.testing.assert_array_equal(loaded_image, expected_image)
+
+
 def test_lossless_vs_lossy_memory_error_increase(tmp_path):
     rng = np.random.default_rng(321)
     test_image = rng.integers(0, 256, (256, 256), dtype=np.uint8)


### PR DESCRIPTION
- Allow 3D arrays with shape (H, W, 1) to be written as monochrome images
- Automatically collapse last dimension when num_components == 1
- Restore compatibility with version 0.4.6 behavior
- Add test case for 3D single channel arrays