### PR TITLE
Add get_level_shape() method to query image dimensions at decomposition levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-01-22
+
+- Provide a new method `get_level_shape` to help get the shape after decoding for
+  the image at a given resolution level.
+
 ## [0.5.1] - 2025-12-29
 
 - Fix writing 3D arrays with a single channel dimension (shape `(H, W, 1)`) as monochrome

--- a/ojph/_imread.py
+++ b/ojph/_imread.py
@@ -230,6 +230,58 @@ class OJPHImageFile:
     def progression_order(self):
         return self._progression_order
 
+    def get_level_shape(self, level):
+        """Get the image shape at a specific decomposition level.
+
+        JPEG2000 wavelet decomposition uses ceiling division for level shapes,
+        so odd dimensions round up. For example, a 97x97 image has level 3
+        shape of 13x13, not 12x12.
+
+        Parameters
+        ----------
+        level : int
+            The decomposition level (0 = full resolution).
+
+        Returns
+        -------
+        tuple
+            The (height, width) or (height, width, channels) shape at that level,
+            matching the format of the `shape` property.
+        """
+        if level < 0:
+            raise ValueError(f"level must be >= 0, got {level}")
+        if level > self._num_decompositions:
+            raise ValueError(
+                f"level ({level}) cannot be greater than the number of "
+                f"decompositions ({self._num_decompositions})"
+            )
+
+        if level == 0:
+            return self._shape
+
+        # JPEG2000 DWT uses ceiling division for level dimensions:
+        # dim_at_level = ceil(dim_at_level0 / 2^level)
+        # In Python: ceil(a/b) = -(-a // b)
+        divisor = 1 << level  # 2^level
+
+        # Get base height/width from shape (accounting for channel position)
+        if self._num_components == 1:
+            height, width = self._shape
+        elif self._channel_order == 'CHW':
+            _, height, width = self._shape
+        else:
+            height, width, _ = self._shape
+
+        level_height = -(-height // divisor)
+        level_width = -(-width // divisor)
+
+        if self._num_components == 1:
+            return (level_height, level_width)
+        elif self._channel_order == 'CHW':
+            return (self._num_components, level_height, level_width)
+        else:
+            return (level_height, level_width, self._num_components)
+
     def _open_file(self):
         self._ojph_file = J2CInfile()
         self._ojph_file.open(self._filename)

--- a/tests/test_imread_from_memory.py
+++ b/tests/test_imread_from_memory.py
@@ -136,3 +136,81 @@ def test_imread_from_memory_non_reversible_no_negative_values():
         f"Min value: {decoded_image.min()}, "
         f"Values below 50: {np.sum(decoded_image < 50)}"
     )
+
+
+@pytest.mark.parametrize('size', [(96, 96), (97, 97), (100, 100), (127, 127), (128, 128)])
+def test_get_level_shape(size):
+    """Test that get_level_shape returns correct dimensions at each level."""
+    test_image = np.random.randint(0, 256, size, dtype=np.uint8)
+    compressed_data = imwrite_to_memory(test_image, num_decompositions=5)
+
+    reader = OJPHImageFile.from_memory(compressed_data)
+
+    # Level 0 should match the original shape
+    assert reader.get_level_shape(0) == size
+
+    # Test each level and verify by actually reading at that level
+    for level in range(1, reader.levels + 1):
+        expected_shape = reader.get_level_shape(level)
+
+        # Create a new reader to actually read at this level
+        reader2 = OJPHImageFile.from_memory(compressed_data)
+        actual_image = reader2.read_image(level=level)
+
+        assert actual_image.shape == expected_shape, (
+            f"Level {level}: get_level_shape returned {expected_shape} "
+            f"but read_image returned shape {actual_image.shape}"
+        )
+
+
+def test_get_level_shape_ceiling_division():
+    """Test that get_level_shape uses ceiling division for odd dimensions."""
+    # 97 is chosen because it doesn't divide evenly by powers of 2
+    test_image = np.random.randint(0, 256, (97, 97), dtype=np.uint8)
+    compressed_data = imwrite_to_memory(test_image, num_decompositions=5)
+
+    reader = OJPHImageFile.from_memory(compressed_data)
+
+    # Expected shapes using ceiling division: ceil(97 / 2^level)
+    expected_shapes = {
+        0: (97, 97),
+        1: (49, 49),  # ceil(97/2) = 49, not 48
+        2: (25, 25),  # ceil(97/4) = 25, not 24
+        3: (13, 13),  # ceil(97/8) = 13, not 12
+        4: (7, 7),    # ceil(97/16) = 7, not 6
+        5: (4, 4),    # ceil(97/32) = 4, not 3
+    }
+
+    for level, expected in expected_shapes.items():
+        assert reader.get_level_shape(level) == expected, (
+            f"Level {level}: expected {expected}, got {reader.get_level_shape(level)}"
+        )
+
+
+def test_get_level_shape_invalid_level():
+    """Test that get_level_shape raises errors for invalid levels."""
+    test_image = np.random.randint(0, 256, (64, 64), dtype=np.uint8)
+    compressed_data = imwrite_to_memory(test_image, num_decompositions=3)
+
+    reader = OJPHImageFile.from_memory(compressed_data)
+
+    with pytest.raises(ValueError, match="level must be >= 0"):
+        reader.get_level_shape(-1)
+
+    with pytest.raises(ValueError, match="cannot be greater than"):
+        reader.get_level_shape(reader.levels + 1)
+
+
+def test_get_level_shape_rgb():
+    """Test get_level_shape with multi-channel images."""
+    test_image = np.random.randint(0, 256, (97, 97, 3), dtype=np.uint8)
+    compressed_data = imwrite_to_memory(test_image, channel_order='HWC', num_decompositions=3)
+
+    reader = OJPHImageFile.from_memory(compressed_data, channel_order='HWC')
+
+    # Level 0 should include channel dimension
+    assert reader.get_level_shape(0) == (97, 97, 3)
+
+    # Other levels should also include channel dimension
+    assert reader.get_level_shape(1) == (49, 49, 3)
+    assert reader.get_level_shape(2) == (25, 25, 3)


### PR DESCRIPTION
## Summary
- Add `get_level_shape(level)` method to `OJPHImageFile` that returns the image dimensions at a given decomposition level
- This allows callers to query the exact shape without reading the image data

## Motivation

JPEG2000 wavelet decomposition uses ceiling division for level shapes, so the shape at level N is NOT simply `floor(shape / 2^N)`. For example, a 97x97 image has these level shapes:
- Level 0: 97x97
- Level 1: 49x49 (not 48x48)
- Level 2: 25x25 (not 24x24)
- Level 3: 13x13 (not 12x12)

Callers that need to pre-allocate buffers or calculate slice indices for reading at lower resolution levels need to know the exact shape. Without this method, they must either:
1. Actually read the image just to get its shape (wasteful)
2. Duplicate the ceiling division logic (error-prone)

## Implementation

The method computes the shape mathematically using the standard JPEG2000 DWT formula:
```
dim_at_level = ceil(dim_at_level0 / 2^level)
```

This is consistent with what `read_image()` returns at each level.

## Test plan

- Added tests that verify `get_level_shape()` matches the actual shape returned by `read_image()` at each level
- Added tests for edge cases: invalid levels, RGB images, various image sizes including odd dimensions

Fixes #24