### PR TITLE
Address memory leak in `imwrite_to_memory()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-01-23
+
+- Fix memory leak in `imwrite_to_memory()`. The codestream and memory outfile are now
+  properly closed after encoding.
+
+
+
 ## [0.6.0] - 2026-01-22
 
 - Provide a new method `get_level_shape` to help get the shape after decoding for

--- a/ojph/_imwrite.py
+++ b/ojph/_imwrite.py
@@ -57,7 +57,10 @@ def imwrite_to_memory(
         tileparts_at_resolutions=tileparts_at_resolutions,
         tileparts_at_components=tileparts_at_components,
     )
-    return np.asarray(CompressedData(mem_outfile, codestream))
+    data = bytes(mem_outfile.get_data())
+    codestream.close()
+    mem_outfile.close()
+    return np.frombuffer(data, dtype=np.uint8)
 
 
 def imwrite(


### PR DESCRIPTION
`imwrite_to_memory()` leaks memory proportional to image size. Each call retains ~15 MB for a 3072×3072 image, leading to multi-gigabyte memory usage when encoding many images.

## Minimal Reproducer

```python
import gc
import numpy as np
import psutil
import ojph

def get_mem_mb():
    return psutil.Process().memory_info().rss / (1024**2)

initial = get_mem_mb()
buffers = []

for i in range(50):
    data = np.random.randint(0, 255, (2048, 2048), dtype='uint8')
    buffers.append(ojph.imwrite_to_memory(data, channel_order='HW'))

    if (i + 1) % 10 == 0:
        gc.collect()
        compressed_mb = sum(len(b) for b in buffers) / (1024**2)
        leaked = get_mem_mb() - initial - compressed_mb
        print(f"After {i+1} images: leaked={leaked:.0f} MB")

gc.collect()
compressed_mb = sum(len(b) for b in buffers) / (1024**2)
leaked = get_mem_mb() - initial - compressed_mb
print(f"\nTotal: compressed={compressed_mb:.0f} MB, leaked={leaked:.0f} MB")
print(f"Leak per image: {leaked/50:.1f} MB")
```

**Expected output (before fix):**
```
After 10 images: leaked=68 MB
After 20 images: leaked=154 MB
After 30 images: leaked=240 MB
After 40 images: leaked=325 MB
After 50 images: leaked=411 MB

Total: compressed=227 MB, leaked=411 MB
Leak per image: 8.2 MB
```

**Expected output (after fix):**
```
After 10 images: leaked=12 MB
After 20 images: leaked=12 MB
After 30 images: leaked=12 MB
After 40 images: leaked=12 MB
After 50 images: leaked=12 MB

Total: compressed=227 MB, leaked=12 MB
Leak per image: 0.2 MB
```
