### PR TITLE
Fix build against latest OpenJPH and require post-#312 OpenJPH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Build against the latest OpenJPH. OpenJPH PR
+  [#312](https://github.com/aous72/OpenJPH/pull/312) ("Removes direct access to
+  COC segment marker") added COC-segment overloads to `ojph::param_cod`, which
+  made the unqualified member-function pointers used by the bindings ambiguous
+  and broke compilation. The affected `param_cod` `.def(...)` bindings are now
+  disambiguated with explicit `static_cast` to the COD (no `comp_idx`) overloads.
+  This change is backward-compatible and still compiles against older OpenJPH
+  where those methods are not overloaded.
+- Bump the minimum required OpenJPH to the version containing PR #312. That
+  change was merged after the 0.30.1 release and is, at the time of writing,
+  only available on OpenJPH `main` (unreleased). Building against OpenJPH 0.30.1
+  or earlier is no longer supported.
+
 ## [0.6.2] - 2026-02-20
 
 - Fix encoding errors associated with datatypes where the order is explicitely defined.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 OpenJPH bindings
+
+## Requirements
+
+These bindings link against [OpenJPH](https://github.com/aous72/OpenJPH) and
+require a version containing PR
+[#312](https://github.com/aous72/OpenJPH/pull/312) ("Removes direct access to
+COC segment marker"). That change was merged after the 0.30.1 release and, at
+the time of writing, is only available on OpenJPH `main` (unreleased). Building
+against OpenJPH 0.30.1 or earlier is not supported.

--- a/ojph/ojph_bindings.cpp
+++ b/ojph/ojph_bindings.cpp
@@ -437,26 +437,29 @@ PYBIND11_MODULE(ojph_bindings, m) {
     py::class_<param_cod>(m, "ParamCod")
         // .def(py::init<local::param_cod*>())
 
-        .def("set_num_decomposition", &param_cod::set_num_decomposition, py::arg("num_decompositions"))
-        .def("set_block_dims", &param_cod::set_block_dims, py::arg("width"), py::arg("height"))
-        .def("set_precinct_size", &param_cod::set_precinct_size, py::arg("num_levels"), py::arg("precinct_size"))
+        // OpenJPH >= 0.30.1 (post-release) added COC-segment overloads that take
+        // a leading comp_idx argument, so these COD-segment (no comp_idx) methods
+        // must be disambiguated with an explicit member-function-pointer cast.
+        .def("set_num_decomposition", static_cast<void (param_cod::*)(ui32)>(&param_cod::set_num_decomposition), py::arg("num_decompositions"))
+        .def("set_block_dims", static_cast<void (param_cod::*)(ui32, ui32)>(&param_cod::set_block_dims), py::arg("width"), py::arg("height"))
+        .def("set_precinct_size", static_cast<void (param_cod::*)(int, size*)>(&param_cod::set_precinct_size), py::arg("num_levels"), py::arg("precinct_size"))
         .def("set_progression_order", &param_cod::set_progression_order, py::arg("name"))
         .def("set_color_transform", &param_cod::set_color_transform, py::arg("color_transform"))
-        .def("set_reversible", &param_cod::set_reversible, py::arg("reversible"))
+        .def("set_reversible", static_cast<void (param_cod::*)(bool)>(&param_cod::set_reversible), py::arg("reversible"))
 
-        .def("get_num_decompositions", &param_cod::get_num_decompositions)
-        .def("get_block_dims", &param_cod::get_block_dims)
-        .def("get_log_block_dims", &param_cod::get_log_block_dims)
-        .def("is_reversible", &param_cod::is_reversible)
-        .def("get_precinct_size", &param_cod::get_precinct_size, py::arg("level_num"))
-        .def("get_log_precinct_size", &param_cod::get_log_precinct_size, py::arg("level_num"))
+        .def("get_num_decompositions", static_cast<ui32 (param_cod::*)() const>(&param_cod::get_num_decompositions))
+        .def("get_block_dims", static_cast<size (param_cod::*)() const>(&param_cod::get_block_dims))
+        .def("get_log_block_dims", static_cast<size (param_cod::*)() const>(&param_cod::get_log_block_dims))
+        .def("is_reversible", static_cast<bool (param_cod::*)() const>(&param_cod::is_reversible))
+        .def("get_precinct_size", static_cast<size (param_cod::*)(ui32) const>(&param_cod::get_precinct_size), py::arg("level_num"))
+        .def("get_log_precinct_size", static_cast<size (param_cod::*)(ui32) const>(&param_cod::get_log_precinct_size), py::arg("level_num"))
         .def("get_progression_order", &param_cod::get_progression_order)
         .def("get_progression_order_as_string", &param_cod::get_progression_order_as_string)
         .def("get_num_layers", &param_cod::get_num_layers)
         .def("is_using_color_transform", &param_cod::is_using_color_transform)
         .def("packets_may_use_sop", &param_cod::packets_may_use_sop)
         .def("packets_use_eph", &param_cod::packets_use_eph)
-        .def("get_block_vertical_causality", &param_cod::get_block_vertical_causality);
+        .def("get_block_vertical_causality", static_cast<bool (param_cod::*)() const>(&param_cod::get_block_vertical_causality));
 
     py::class_<param_qcd>(m, "ParamQcd")
         .def("set_irrev_quant", static_cast<void (param_qcd::*)(float)>(&param_qcd::set_irrev_quant), py::arg("delta"))

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,10 @@ ojph_module = Extension(
     sources=['ojph/ojph_bindings.cpp'],
     include_dirs=include_dirs,
     library_dirs=library_dirs,
+    # Requires OpenJPH containing PR #312 (COC segment overloads), which was
+    # merged after the 0.30.1 release. As of this writing that change is only
+    # available on OpenJPH `main` (unreleased); OpenJPH <= 0.30.1 will not
+    # compile. See CHANGELOG.md for details.
     libraries=['openjph'],
     extra_compile_args=[]
 )


### PR DESCRIPTION
<details><summary>Claude's draft</summary>

OpenJPH PR #312 ("Removes direct access to COC segment marker") added COC-segment overloads to `ojph::param_cod`. These overloads made the unqualified member-function pointers `&param_cod::method` used by the pybind11 bindings ambiguous, producing 11 "no matching member function for call to 'def'" compile errors against the latest OpenJPH.

Disambiguate each affected `.def(...)` in the `ParamCod` class block with an explicit `static_cast` to the COD (no `comp_idx`) overload. This is backward-compatible: it also compiles against older OpenJPH where the methods are not overloaded.

Also bump the minimum required OpenJPH to the version containing PR #312 (merged after 0.30.1, currently only on OpenJPH `main`). Documented in setup.py, README.md, and CHANGELOG.md.

Build (`pip install -e . --no-build-isolation`) succeeds and all 101 tests pass in the `mcam_dev` environment.

Resume this Claude session:
```
cd /Users/mark/git/ht2k/ojph
claude --resume 25579e5b-22dc-4248-a3e3-e8c2399bbd6c
```
</details>