### PR TITLE
Fix PyPI publish: grant id-token: write for attestations

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -110,6 +110,12 @@ jobs:
     runs-on: ubuntu-latest
     # Only on tag pushes in the canonical repo.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      # pypa/gh-action-pypi-publish generates PEP 740 attestations by default,
+      # which requires an OIDC token. Without this the publish fails with
+      # "OIDC token retrieval failed ... the ACTIONS_ID_TOKEN_REQUEST_TOKEN
+      # environment variable was unset". Also enables Trusted Publishing.
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## The failure (found on `main` after #30 merged)
The `0.8.0rc1` tag build built every wheel + the sdist successfully, but **Publish to PyPI failed**:

```
Trusted publishing exchange failure: OIDC token retrieval failed:
GitHub: missing or insufficient OIDC token permissions,
the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable was unset ...
Make sure that your workflow has `id-token: write` configured
```

So `0.8.0rc1` never reached PyPI.

## Cause
`pypa/gh-action-pypi-publish` generates [PEP 740 attestations](https://peps.python.org/pep-0740/) by default, which requires an OIDC token (`id-token: write`). When the publish job was simplified in #30, that permission was dropped.

## Fix
Grant `permissions: id-token: write` to the `publish` job. Upload still authenticates with `PYPI_API_TOKEN`; the OIDC token is used for attestations (and would also enable Trusted Publishing if you switch to it later).

## To release
Re-push a tag (e.g. `0.8.0rc2`, or delete/re-create `0.8.0rc1`) once this merges, and the publish will go through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)