### PR TITLE
Automate rc tags as PyPI pre-releases + GitHub pre-releases

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      # Only publish proper PEP 440 version tags. Final releases (0.8.0) and
+      # release candidates (0.8.0rc1) build + publish; anything else is ignored.
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
   pull_request:
   workflow_dispatch:
 
@@ -108,7 +111,8 @@ jobs:
     name: Publish to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    # Only on tag pushes in the canonical repo.
+    # Only on version-tag pushes. The `on.push.tags` filter already restricts
+    # this to X.Y.Z / X.Y.ZrcN tags, so any tag reaching here is publishable.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     permissions:
       # pypa/gh-action-pypi-publish generates PEP 740 attestations by default,
@@ -116,6 +120,8 @@ jobs:
       # "OIDC token retrieval failed ... the ACTIONS_ID_TOKEN_REQUEST_TOKEN
       # environment variable was unset". Also enables Trusted Publishing.
       id-token: write
+      # Needed to create/update the GitHub Release for the tag.
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -123,9 +129,31 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Classify tag (release vs release candidate)
+        id: classify
+        shell: bash
+        run: |
+          # PyPI/PEP 440 treats an ``rc`` version as a pre-release automatically
+          # (pip skips it unless --pre). We mirror that on the GitHub Release by
+          # marking rc tags as pre-releases.
+          if [[ "${GITHUB_REF_NAME}" == *rc* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
           password: ${{ secrets.PYPI_API_TOKEN }}
           print-hash: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          # Mark release candidates (rc tags) as GitHub pre-releases.
+          prerelease: ${{ steps.classify.outputs.prerelease }}
+          # Attach the built wheels and sdist to the release.
+          files: dist/*
+          generate_release_notes: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -110,6 +110,12 @@ jobs:
     runs-on: ubuntu-latest
     # Only on tag pushes in the canonical repo.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      # pypa/gh-action-pypi-publish generates PEP 740 attestations by default,
+      # which requires an OIDC token. Without this the publish fails with
+      # "OIDC token retrieval failed ... the ACTIONS_ID_TOKEN_REQUEST_TOKEN
+      # environment variable was unset". Also enables Trusted Publishing.
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Automate release-candidate publishing straight from tags.

## Behavior
| Tag | Builds | PyPI | GitHub Release |
|---|---|---|---|
| `0.8.0` (final) | ✅ | full release | normal release |
| `0.8.0rc1` (rc) | ✅ | **pre-release** (PEP 440 → `pip` needs `--pre`) | marked **pre-release** |
| anything else (`nightly`, `foo`) | ❌ ignored | — | — |

## Changes
- **`on.push.tags`** restricted to PEP 440 version tags — `[0-9]+.[0-9]+.[0-9]+` and `[0-9]+.[0-9]+.[0-9]+rc[0-9]+` — so only real releases/rcs build and publish (no wasted builds, no accidental publishes). Matches the project's unprefixed tag convention (`0.8.0rc1`).
- **Publish** to production PyPI. An `rc` version is a pre-release automatically under PEP 440, so `pip install ojph` won't pick it up unless you pass `--pre` — exactly the "release candidate on PyPI" behavior.
- **GitHub Release** created for the tag, marked `prerelease: true` for rc tags, with the built wheels + sdist attached and auto-generated notes.

## Notes
- Built on top of #31 (adds `id-token: write` so publishing actually works) — this branch includes that fix, so merging it alone is sufficient. If #31 merges first, this PR reduces to just the rc-automation changes.
- To use: push a tag like `0.8.0rc2` → wheels build → published to PyPI as a pre-release → GitHub pre-release created. Only alpha/beta (`aN`/`bN`) aren't included yet; easy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)