### PR TITLE
Version tag builds from the pushed tag, not git describe

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -56,7 +56,18 @@ jobs:
 
       - name: Compute version string
         shell: bash
-        run: echo "OJPH_GIT_DESCRIBE=$(git describe --tags --long --always)" >> "$GITHUB_ENV"
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            # On a tag build, pin the version to the *pushed* tag. `git describe`
+            # is ambiguous when several tags share a commit (e.g. 0.8.0,
+            # 0.8.0rc2, 0.8.0rc3 all on one commit) and would otherwise label
+            # the wheels with the wrong tag. The "-0-g<sha>" suffix is the
+            # `git describe --long` shape miniver expects (distance 0 => the
+            # version is exactly the tag).
+            echo "OJPH_GIT_DESCRIBE=${GITHUB_REF_NAME}-0-g$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          else
+            echo "OJPH_GIT_DESCRIBE=$(git describe --tags --long --always)" >> "$GITHUB_ENV"
+          fi
 
       - name: Install CMake and Ninja (host)
         # The manylinux container gets these via pip in CIBW before-all; on the
@@ -97,7 +108,18 @@ jobs:
 
       - name: Compute version string
         shell: bash
-        run: echo "OJPH_GIT_DESCRIBE=$(git describe --tags --long --always)" >> "$GITHUB_ENV"
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            # On a tag build, pin the version to the *pushed* tag. `git describe`
+            # is ambiguous when several tags share a commit (e.g. 0.8.0,
+            # 0.8.0rc2, 0.8.0rc3 all on one commit) and would otherwise label
+            # the wheels with the wrong tag. The "-0-g<sha>" suffix is the
+            # `git describe --long` shape miniver expects (distance 0 => the
+            # version is exactly the tag).
+            echo "OJPH_GIT_DESCRIBE=${GITHUB_REF_NAME}-0-g$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          else
+            echo "OJPH_GIT_DESCRIBE=$(git describe --tags --long --always)" >> "$GITHUB_ENV"
+          fi
 
       - name: Build sdist
         run: pipx run build --sdist


### PR DESCRIPTION
## Symptom
Pushing `0.8.0rc3` published wheels named **`ojph-0.8.0rc2-*`** to PyPI — the wrong version. (Auth is fine now; the publish itself succeeded.)

## Cause
The version is computed with `git describe --tags`, which is **ambiguous when multiple tags point at the same commit**. `0.8.0`, `0.8.0rc2`, and `0.8.0rc3` were all created on the same commit (`ec25c85`), so `git describe` returned an arbitrary one (not the pushed tag):

```
$ git describe --tags --long   # at that commit
0.8.0-0-gec25c85               # picks 0.8.0 now; picked 0.8.0rc2 during the rc3 run
```

## Fix
On a **tag** build, derive the version from the pushed tag ref (`GITHUB_REF_NAME`) instead of `git describe`, formatted as `<tag>-0-g<sha>` so miniver reads it as exactly the tag. Branch builds keep using `git describe`. Applied to both the wheels and sdist jobs.

Verified locally: `OJPH_GIT_DESCRIBE=0.8.0rc3-0-g<sha>` → miniver version `0.8.0rc3`.

## After merging — cleanup
- The stale tags (`0.8.0`, `0.8.0rc2`, `0.8.0rc3`) all sit on the pre-fix commit and will keep mis-labeling if rebuilt. Cut a **fresh** tag on the fixed `main` (e.g. `0.8.0rc4`) to publish correctly.
- PyPI now has a bogus **`0.8.0rc2`** (uploaded by the rc3 run). Consider yanking/deleting it at https://pypi.org/manage/project/ojph/releases/ . Note `rc3` is still free on PyPI; `rc2` can't be reused once deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)