### PR TITLE
tests: use git describe --long so on-tag builds don't break

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,16 +47,18 @@ jobs:
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-      - uses: proudust/gh-describe@v2
-        # id needed to generate the outputs
-        id: ghd
-      - name: Check outputs
+      - name: Compute version string
+        # Use `git describe --long` so miniver always receives the
+        # "<tag>-<distance>-g<sha>" form it can parse -- even when HEAD is
+        # exactly on a tag (distance 0). The previous gh-describe action returned
+        # the bare tag in that case, which miniver turned into the invalid
+        # version "unknown+g<tag>" and broke `pip install`. Written to
+        # $GITHUB_ENV so both the Unix and Windows steps pick it up.
+        shell: bash
         run: |
-          echo "describe  : ${{ steps.ghd.outputs.describe }}"
-          echo "tag       : ${{ steps.ghd.outputs.tag }}"
-          echo "distance  : ${{ steps.ghd.outputs.distance }}"
-          echo "sha       : ${{ steps.ghd.outputs.sha }}"
-          echo "short-sha : ${{ steps.ghd.outputs.short-sha }}"
+          describe="$(git describe --tags --long --always)"
+          echo "describe: $describe"
+          echo "OJPH_GIT_DESCRIBE=$describe" >> "$GITHUB_ENV"
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
@@ -71,7 +73,6 @@ jobs:
           conda info
           conda list
           conda install --quiet compilers pybind11 numpy openjph setuptools pytest --yes
-          export OJPH_GIT_DESCRIBE=${{ steps.ghd.outputs.describe }}
           python -m pip install -e . -vvv --no-deps --no-build-isolation --disable-pip-version-check
           python --version
 
@@ -90,8 +91,6 @@ jobs:
           conda info
           conda list
           conda install --yes --quiet compilers pybind11 numpy openjph setuptools pytest git
-          set "OJPH_GIT_DESCRIBE=${{ steps.ghd.outputs.describe }}"
-          setx OJPH_GIT_DESCRIBE ${{ steps.ghd.outputs.describe }}
           python -m pip install -e . -vvv --no-deps --no-build-isolation --disable-pip-version-check
           python --version
 


### PR DESCRIPTION
## Symptom
`Testing` jobs on `main` failed at `pip install -e .`:
```
packaging.version.InvalidVersion: Invalid version: 'unknown+g0.8.0rc2'
```
(e.g. [this run](https://github.com/ramonaoptics/ojph/actions/runs/28711896476) — some macOS jobs failed while others passed.)

## Cause
`tests.yml` computed the version with `proudust/gh-describe`, whose `describe` output is the **bare tag** when HEAD is exactly on a tag (distance 0). miniver (`ojph/_version.py`) expects the `git describe --long` form `<tag>-<distance>-g<sha>` and does `rsplit("-", 2)`; a bare `0.8.0rc2` has no dashes, so it falls to the "unknown" branch → `unknown+g0.8.0rc2` → setuptools rejects it.

It surfaced because the `#32` merge commit got tagged `0.8.0` / `0.8.0rc2` / `0.8.0rc3` right as the push triggered CI — a race. Jobs that fetched tags first saw `0.8.0rc1-4-gec25c85` (distance 4, long form → OK); jobs that fetched after saw the bare on-tag `0.8.0rc2` (distance 0 → broke). It also recurs any time `main`'s HEAD lands on a tag.

## Fix
Replace `gh-describe` with `git describe --tags --long --always` — always the long, parseable form, even at distance 0 — written to `$GITHUB_ENV` so both the Unix and Windows install steps pick it up. Drops the now-redundant per-step `OJPH_GIT_DESCRIBE` `export`/`set`. This mirrors what `wheels.yml` already does.

Verified locally at the multiply-tagged `ec25c85`: `git describe --tags --long --always` → `0.8.0-0-gec25c85` → miniver resolves a valid `0.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)