### PR TITLE
Tell PyPI the README is Markdown, and check it on every PR

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -124,6 +124,14 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
+      - name: Check the distribution metadata renders on PyPI
+        # The same `twine check` that pypa/gh-action-pypi-publish runs before it
+        # uploads. Running it here means a README that PyPI would reject fails on
+        # the pull request, rather than after a release tag has been pushed and
+        # every wheel has already been built. The metadata is identical in the
+        # wheels, so checking the sdist is enough.
+        run: pipx run twine check --strict dist/*.tar.gz
+
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-sdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matrix.
 - Advertise free-threading support with the
   `Programming Language :: Python :: Free Threading :: 3 - Stable` classifier.
+- Declare `long_description_content_type='text/markdown'`. The README has always
+  been Markdown, but without this PyPI parses it as reStructuredText and rejects
+  the upload once it contains anything that is not also valid RST -- such as a
+  fenced code block. `twine check --strict` now runs on every pull request, so
+  this fails there instead of after a release tag has been pushed.
 
 ## [0.7.0] - 2026-07-03
 

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,10 @@ setup(
     cmdclass=cmdclass,
     description='OpenJPH Bindings for Python and Numpy',
     long_description=readme,
+    # README.md is Markdown. Without this, PyPI (and `twine check`) fall back to
+    # reStructuredText and reject the upload as soon as the README contains
+    # anything that is not also valid RST -- a fenced code block, for instance.
+    long_description_content_type='text/markdown',
     url='https://github.com/ramonaoptics/ojph',
     author='Mark Harfouche',
     author_email='mark@ramonaoptics.com',


### PR DESCRIPTION
The 0.9.0 release built all seven wheel sets and the sdist successfully, then failed in `Publish to PyPI` — before uploading anything:

```
ERROR   `long_description` has syntax errors in markup and would not be rendered on PyPI.
        line 22: Warning: Inline literal start-string without end-string.
WARNING `long_description_content_type` missing. defaulting to `text/x-rst`.
```

**Nothing was published.** `twine check` runs before the upload, so PyPI is still at 0.8.1 and no GitHub Release was created. The `0.9.0` tag exists but produced no artifacts.

## Cause

`setup.py` passes `README.md` to `long_description` but never declared the content type, so twine assumed reStructuredText. The README has always been Markdown — it just happened to also be *valid RST* until the free-threading section added a fenced code block at line 22, where ` ``` ` is an unterminated inline literal.

Fix: `long_description_content_type='text/markdown'`.

## Why it got as far as a release tag

Nothing validated the distribution metadata until the `publish` job, which only runs on tag pushes. Every PR was green; the first signal was a failed release.

The sdist job now runs the same `twine check --strict` that `gh-action-pypi-publish` runs, on every PR. The metadata is identical in the wheels, so checking the sdist catches it for all of them.

## Verification

Reproduced the exact failure locally against the sdist built from the tagged tree, then confirmed the fix:

```
before:  ojph-0.9.0.tar.gz: FAILED
         line 22: Warning: Inline literal start-string without end-string.
after:   ojph-0.9.0+dirty.tar.gz: PASSED   (twine check --strict)
```

## Note on the tag

`0.9.0` is currently tagged but unpublished. Since nothing was uploaded, the version number is still free — the tag can be moved to the fix commit, or burned in favour of `0.9.1`. Holding for a decision rather than assuming.

https://claude.ai/code/session_018ypyZ8QPYGXpYiNALQCSDy